### PR TITLE
EXT-316: Save user settings

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,91 +1,99 @@
+let previousURL = null;
 
-let previousURL = null
-
-const SETTINGS_KEY = 'ext_set'
+const SETTINGS_KEY = "ext_set";
+const KEYS = ['l', 'locale', 's', 'a', 'b', 'theme', 'ta']
 
 const deleteEmpty = (obj) => {
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         if (obj[key] === undefined) {
             delete obj[key];
         }
     });
-    return obj
-}
+    return obj;
+};
 
 const getParams = (url) => {
-    const params = {}
-
-    const urlParams = new URLSearchParams(url.replace('https://lite.qwant.com/', '').replace('https://lite.qwant.com/settings', ''));
-
+    const params = {};
+    const urlParams = new URLSearchParams(
+        url
+            .replace("https://lite.qwant.com/", "")
+            .replace("https://lite.qwant.com/settings", "")
+    );
     const entries = urlParams.entries();
+
     for (const entry of entries) {
-        params[entry[0]] = entry[1]
+        params[entry[0]] = entry[1];
     }
 
-    return deleteEmpty(params)
-}
-
-const isSearchQuery = ({ method, type, url }) => {
-    if (method !== "GET" || type !== "main_frame") return false
-    return !!getParams(url).q
-}
+    return deleteEmpty(params);
+};
 
 const saveSettings = (url) => {
-    const settings = getParams(url)
+    const settings = getParams(url);
 
-    delete settings.q
-    delete settings['settings?']
-    delete settings['settings?q']
+    delete settings.q;
+    delete settings["settings?"];
+    delete settings["settings?q"];
 
-    browser.storage.local.set({ settings })
-    return settings
-}
+    browser.storage.local.set({
+        settings
+    });
+
+    return settings;
+};
 
 const getSearchQuery = async (url) => {
-    const { q, ...params } = getParams(url)
-    const result = {}
+    const { q, ...params } = getParams(url);
+    const { settings } = await browser.storage.local.get("settings");
 
-    const { settings } = await browser.storage.local.get("settings")
+    if (!settings || Object.keys(settings).length === 0) {
+        return null;
+    }
 
-    if (!settings || Object.keys(settings).length === 0) { return null }
-
-    Object.keys(settings).forEach(key => {
-        result[key] = settings[key]
-    })
-
-    Object.keys(params).forEach(key => {
-        result[key] = params[key]
-    })
+    const result = {};
+    Object.keys(settings).forEach((key) => {
+        if (KEYS.includes(key.toLocaleLowerCase()) && settings[key]) {
+            result[key] = settings[key];
+        }
+    });
+    Object.keys(params).forEach((key) => {
+        if (params[key]) {
+            result[key] = params[key];
+        }
+    });
 
     const query = new URLSearchParams({
         q,
         ...result,
         [SETTINGS_KEY]: "1"
-    }).toString()
+    }).toString();
 
-    return query
-}
+    return query;
+};
 
 browser.webRequest.onBeforeRequest.addListener(
     async (info) => {
-        if (info.method !== "GET" || info.type !== "main_frame") return
+        if (info.method !== "GET" || info.type !== "main_frame") return;
+        const queryParams = getParams(info.url);
 
-        const queryParams = getParams(info.url)
-
-        // User save new settings
-        if (previousURL && previousURL.startsWith('https://lite.qwant.com/settings')) {
-            saveSettings(info.url)
+        if (
+            previousURL &&
+            previousURL.startsWith("https://lite.qwant.com/settings")
+        ) {
+            saveSettings(info.url);
         } else if (!!queryParams.q && !queryParams[SETTINGS_KEY]) {
-            const searchParams = await getSearchQuery(info.url)
+            const searchParams = await getSearchQuery(info.url);
+
             if (searchParams) {
                 return {
                     redirectUrl: "https://lite.qwant.com/?" + searchParams
-                }
+                };
             }
         }
-
-        previousURL = info.url
+        previousURL = info.url;
     },
-    { urls: ["https://lite.qwant.com/*"] },
+    {
+        urls: ["https://lite.qwant.com/*"]
+    },
     ["blocking"]
 );

--- a/background.js
+++ b/background.js
@@ -1,0 +1,101 @@
+
+let previousURL = null
+
+const deleteEmpty = (obj) => {
+    Object.keys(obj).forEach(key => {
+        if (obj[key] === undefined) {
+            delete obj[key];
+        }
+    });
+    return obj
+}
+
+
+const getParams = (url) => {
+    const params = {
+        a: undefined,
+        b: undefined,
+        l: undefined,
+        locale: undefined,
+        q: undefined,
+        s: undefined,
+        ta: undefined,
+        theme: undefined,
+    }
+
+    const urlParams = new URLSearchParams(url.replace('https://lite.qwant.com/', '').replace('https://lite.qwant.com/settings', ''));
+    const entries = urlParams.entries();
+
+    for (const entry of entries) {
+        params[entry[0]] = entry[1]
+    }
+
+    return deleteEmpty(params)
+}
+
+const isSearchQuery = ({ method, type, url }) => {
+    if (method !== "GET" || type !== "main_frame") return false
+    return !!getParams(url).q
+}
+
+const saveSettings = (url) => {
+    const settings = getParams(url)
+
+    delete settings.q
+    delete settings['settings?']
+    delete settings['settings?q']
+
+    browser.storage.local.set({ settings })
+    return settings
+}
+
+const getSearchQuery = async (url) => {
+    const { q, ...params } = getParams(url)
+    const result = {}
+
+    const { settings } = await browser.storage.local.get("settings")
+
+    if (!settings || Object.keys(settings).length === 0) { return null }
+
+    Object.keys(settings).forEach(key => {
+        result[key] = settings[key]
+    })
+
+    Object.keys(params).forEach(key => {
+        result[key] = params[key]
+    })
+
+    const query = new URLSearchParams({
+        q,
+        ...result,
+        qlite_settings: "1"
+    }).toString()
+
+    return query
+}
+
+browser.webRequest.onBeforeRequest.addListener(
+    async (info) => {
+        if (info.method !== "GET" || info.type !== "main_frame") return
+
+        const queryParams = getParams(info.url)
+
+        // User save new settings
+        if (previousURL && previousURL.startsWith('https://lite.qwant.com/settings')) {
+            saveSettings(info.url)
+        } else if (isSearchQuery(info)) {
+            if (!queryParams.qlite_settings) {
+                const searchParams = await getSearchQuery(info.url)
+                if (searchParams) {
+                    return {
+                        redirectUrl: "https://lite.qwant.com/?" + searchParams
+                    }
+                }
+            }
+        }
+
+        previousURL = info.url
+    },
+    { urls: ["https://lite.qwant.com/*"] },
+    ["blocking"]
+);

--- a/background.js
+++ b/background.js
@@ -1,6 +1,8 @@
 
 let previousURL = null
 
+const SETTINGS_KEY = 'ext_set'
+
 const deleteEmpty = (obj) => {
     Object.keys(obj).forEach(key => {
         if (obj[key] === undefined) {
@@ -10,22 +12,12 @@ const deleteEmpty = (obj) => {
     return obj
 }
 
-
 const getParams = (url) => {
-    const params = {
-        a: undefined,
-        b: undefined,
-        l: undefined,
-        locale: undefined,
-        q: undefined,
-        s: undefined,
-        ta: undefined,
-        theme: undefined,
-    }
+    const params = {}
 
     const urlParams = new URLSearchParams(url.replace('https://lite.qwant.com/', '').replace('https://lite.qwant.com/settings', ''));
-    const entries = urlParams.entries();
 
+    const entries = urlParams.entries();
     for (const entry of entries) {
         params[entry[0]] = entry[1]
     }
@@ -68,7 +60,7 @@ const getSearchQuery = async (url) => {
     const query = new URLSearchParams({
         q,
         ...result,
-        qlite_settings: "1"
+        [SETTINGS_KEY]: "1"
     }).toString()
 
     return query
@@ -83,13 +75,11 @@ browser.webRequest.onBeforeRequest.addListener(
         // User save new settings
         if (previousURL && previousURL.startsWith('https://lite.qwant.com/settings')) {
             saveSettings(info.url)
-        } else if (isSearchQuery(info)) {
-            if (!queryParams.qlite_settings) {
-                const searchParams = await getSearchQuery(info.url)
-                if (searchParams) {
-                    return {
-                        redirectUrl: "https://lite.qwant.com/?" + searchParams
-                    }
+        } else if (!!queryParams.q && !queryParams[SETTINGS_KEY]) {
+            const searchParams = await getSearchQuery(info.url)
+            if (searchParams) {
+                return {
+                    redirectUrl: "https://lite.qwant.com/?" + searchParams
                 }
             }
         }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Qwant Lite",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "default_locale": "en",
   "description": "__MSG_description__",
   "icons": {
@@ -34,5 +34,16 @@
         "css/qwant.css"
       ]
     }
+  ],
+  "background": {
+    "scripts": [
+      "background.js"
+    ]
+  },
+  "permissions": [
+    "storage",
+    "https://lite.qwant.com/*",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -42,8 +42,8 @@
   },
   "permissions": [
     "storage",
-    "https://lite.qwant.com/*",
     "webRequest",
-    "webRequestBlocking"
+    "webRequestBlocking",
+    "https://lite.qwant.com/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Qwant Lite",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "default_locale": "en",
   "description": "__MSG_description__",
   "icons": {


### PR DESCRIPTION
A proposal implementation to save user settings #4 

Requires additional permissions like:

1. `storage` To store and fetch the user settings
2. `webRequest` to use `onBeforeRequest` to listen to settings change and queries 
3. `webRequestBlocking` to be able to redirect the query with the appropriate settings applied